### PR TITLE
Fix issue where accepting/rejecting cookies resets your scroll position

### DIFF
--- a/src/assets/js/cookieConsent.js
+++ b/src/assets/js/cookieConsent.js
@@ -48,12 +48,16 @@ window.onload = () => {
   const rejectBtn = document.getElementById("reject");
 
   const acceptCookie = (event) => {
+    event.preventDefault();
+
     saveAcceptToStorage(storageType);
     consentPopup.classList.add("hide");
     applyMatomoTrackingCode();
   };
 
   const rejectCookie = (event) => {
+    event.preventDefault();
+
     saveRejectToStorage(storageType);
     consentPopup.classList.add("hide");
   };


### PR DESCRIPTION
Currently, clicking Accept or Reject scrolls you back to the top of the page.

https://github.com/audacity/audacity.github.io/assets/34525547/25fe91f2-900f-48d8-a6cd-a4a578a8b27f

