### PR TITLE
Fix incorrect blog link meta data

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -7,8 +7,12 @@ import { ViewTransitions } from "astro:transitions";
 
 export interface Props {
   title: string;
+  description: string;
 }
-const { title } = Astro.props;
+const {
+  title = "Audacity | Free Audio editor, recorder, music making and more!",
+  description = "Audacity is the world's most popular audio editing and recording app. Edit, mix, and enhance your audio tracks with the power of Audacity. Download now!",
+} = Astro.props;
 ---
 
 <!doctype html>
@@ -22,11 +26,11 @@ const { title } = Astro.props;
     <link rel="sitemap" href="/sitemap-index.xml" />
     <meta
       name="title"
-      content="Audacity | Free Audio editor, recorder, music making and more!"
+      content={title}
     />
     <meta
       name="description"
-      content="Audacity is the world's most popular audio editing and recording app. Edit, mix, and enhance your audio tracks with the power of Audacity. Download now!"
+      content={description}
     />
     <meta
       name="keywords"
@@ -49,5 +53,5 @@ const { title } = Astro.props;
       <script src="../assets/js/cookieConsent.js"></script>
     </body>
   </main>
-
+  
 </html>

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -20,7 +20,7 @@ const options = {
 };
 ---
 
-<BaseLayout title={"Audacity ® | " + post.data.title}>
+<BaseLayout title={"Audacity ® | " + post.data.title} description={post.data.description}>
   <article id="main" class="prose prose-blue mx-6 sm:mx-12 md:mx-24 lg:mx-auto pt-16 pb-40">
     <div class="flex flex-col gap-2 border-b pb-6">
       <h2 class="my-0">{post.data.title}</h2>


### PR DESCRIPTION
- Added default values for _title_ and _description_ props in Base Layout
- Pulled title and description data from blog post and passed into Base Layout

Expected behaviour - when sharing a link to a blog post, the link preview will show the correct title and description for that blog post.