### PR TITLE
Install and configure postcss-nesting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,8 @@
 				"tailwindcss": "^3.2.6"
 			},
 			"devDependencies": {
-				"@tailwindcss/typography": "^0.5.10"
+				"@tailwindcss/typography": "^0.5.10",
+				"postcss-nesting": "^12.0.2"
 			}
 		},
 		"node_modules/@ampproject/remapping": {
@@ -488,6 +489,28 @@
 			},
 			"engines": {
 				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@csstools/selector-specificity": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-3.0.1.tgz",
+			"integrity": "sha512-NPljRHkq4a14YzZ3YD406uaxh7s0g6eAq3L9aLOWywoqe8PkYamAvtsh7KNX6c++ihDrJ0RiU+/z7rGnhlZ5ww==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"engines": {
+				"node": "^14 || ^16 || >=18"
+			},
+			"peerDependencies": {
+				"postcss-selector-parser": "^6.0.13"
 			}
 		},
 		"node_modules/@emotion/is-prop-valid": {
@@ -5142,10 +5165,36 @@
 				"postcss": "^8.2.14"
 			}
 		},
+		"node_modules/postcss-nesting": {
+			"version": "12.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-12.0.2.tgz",
+			"integrity": "sha512-63PpJHSeNs93S3ZUIyi+7kKx4JqOIEJ6QYtG3x+0qA4J03+4n0iwsyA1GAHyWxsHYljQS4/4ZK1o2sMi70b5wQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"dependencies": {
+				"@csstools/selector-specificity": "^3.0.1",
+				"postcss-selector-parser": "^6.0.13"
+			},
+			"engines": {
+				"node": "^14 || ^16 || >=18"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4"
+			}
+		},
 		"node_modules/postcss-selector-parser": {
-			"version": "6.0.11",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz",
-			"integrity": "sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==",
+			"version": "6.0.15",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.15.tgz",
+			"integrity": "sha512-rEYkQOMUCEMhsKbK66tbEU9QVIxbhN18YiniAwA7XQYTVBqrBy+P2p5JcdqsHgKM2zWylp8d7J6eszocfds5Sw==",
 			"dependencies": {
 				"cssesc": "^3.0.0",
 				"util-deprecate": "^1.0.2"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 		"tailwindcss": "^3.2.6"
 	},
 	"devDependencies": {
-		"@tailwindcss/typography": "^0.5.10"
+		"@tailwindcss/typography": "^0.5.10",
+		"postcss-nesting": "^12.0.2"
 	}
 }

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,8 @@
+module.exports = {
+    plugins: {
+      'postcss-import': {},
+      'tailwindcss/nesting': 'postcss-nesting',
+      tailwindcss: {},
+      autoprefixer: {},
+    }
+  }


### PR DESCRIPTION
Correctly configured postcss-nesting to remove Nested CSS detected error as shown below. This was caused by the cookie consent banner that required nested styling when the "hide" class was added to it once Visitors accept or reject site cookies.

For more info visit https://docs.astro.build/en/guides/styling/#postcss

`[vite:css] Nested CSS was detected, but CSS nesting has not been configured correctly.
Please enable a CSS nesting plugin *before* Tailwind in your configuration.
See how here: https://tailwindcss.com/docs/using-with-preprocessors#nesting
108|          transition: bottom .5s ease;
109|  
110|          &.hide{
   |           ^
111|             bottom:-412px;
112|          }
[vite:css] Nested CSS was detected, but CSS nesting has not been configured correctly.
Please enable a CSS nesting plugin *before* Tailwind in your configuration.
See how here: https://tailwindcss.com/docs/using-with-preprocessors#nesting
1  |  @tailwind base;
   |   ^
2  |  @tailwind components;
3  |  @tailwind utilities;
11:10:11 AM [serve]    404                              /output.css
[vite:css] Nested CSS was detected, but CSS nesting has not been configured correctly.
Please enable a CSS nesting plugin *before* Tailwind in your configuration.
See how here: https://tailwindcss.com/docs/using-with-preprocessors#nesting
108|          transition: bottom .5s ease;
109|  
110|          &.hide{
   |           ^
111|             bottom:-412px;
112|          }
[vite:css] Nested CSS was detected, but CSS nesting has not been configured correctly.
Please enable a CSS nesting plugin *before* Tailwind in your configuration.
See how here: https://tailwindcss.com/docs/using-with-preprocessors#nesting
1  |  @tailwind base;
   |   ^
2  |  @tailwind components;
3  |  @tailwind utilities;
`