### PR TITLE
Implement post-download page

### DIFF
--- a/src/components/button/AudacityInstallerButton.jsx
+++ b/src/components/button/AudacityInstallerButton.jsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+function AudacityInstallerButton(props) {
+  const { museHubReleaseData } = props;
+  function onClickButtonHandler() {
+    setTimeout(() => {
+        window.location.href = "/post-download";
+      }, 2000);
+  }
+  
+  return (
+    <a
+      onClick={onClickButtonHandler}
+      href={museHubReleaseData[0].browser_download_url}
+      className="flex justify-center text-center items-center px-4 h-12 w-full sm:w-fit bg-blue-700 hover:bg-blue-600 text-base text-white rounded"
+    >
+      Download
+    </a>
+  );
+}
+
+export default AudacityInstallerButton;

--- a/src/components/button/DownloadButton.jsx
+++ b/src/components/button/DownloadButton.jsx
@@ -20,6 +20,10 @@ function DownloadButton() {
         ]);
       }
     }
+
+    setTimeout(() => {
+      window.location.href = "download-success";
+    }, 2000);
   }
 
   function renderButton(href) {
@@ -44,7 +48,7 @@ function DownloadButton() {
     case "Debian":
     case "Red Hat":
     case "SuSE":
-      return; //primary button is Linux downlaod already 
+      return; //primary button is Linux download already
     default:
       return renderButton("/download");
   }

--- a/src/components/button/DownloadMuseHubButton.jsx
+++ b/src/components/button/DownloadMuseHubButton.jsx
@@ -31,6 +31,10 @@ function DownloadMuseHubButton() {
         `Download Audacity button ${platform.os.family}`,
       ]);
     }
+
+    setTimeout(() => {
+      window.location.href = "post-download";
+    }, 2000);
   }
 
   function renderButton(href) {

--- a/src/components/button/DownloadMuseHubButton.jsx
+++ b/src/components/button/DownloadMuseHubButton.jsx
@@ -20,7 +20,7 @@ function DownloadMuseHubButton() {
           "trackEvent",
           "Download Button",
           "Download Muse Hub",
-          `Download Muse Hub button ${platform.os.family}`,
+          `Download Muse Hub button ${browserOS}`,
         ]);
       }
     } else if (href === audacityReleases.lin[0].browser_download_url) {
@@ -28,7 +28,7 @@ function DownloadMuseHubButton() {
         "trackEvent",
         "Download Button",
         "Download Audacity",
-        `Download Audacity button ${platform.os.family}`,
+        `Download Audacity button ${browserOS}`,
       ]);
     }
 

--- a/src/components/button/JoinAudioDotComButton.jsx
+++ b/src/components/button/JoinAudioDotComButton.jsx
@@ -1,28 +1,28 @@
-import React from 'react'
+import React from "react";
 
 function handleButtonClick() {
-    if (typeof _paq !== "undefined") {
-      _paq.push([
-        "trackEvent",
-        "CTA Button",
-        "audio.com CTA",
-        "audio.com block CTA",
-      ]);
-    }
+  if (typeof _paq !== "undefined") {
+    _paq.push([
+      "trackEvent",
+      "CTA Button",
+      "audio.com CTA",
+      "audio.com block CTA",
+    ]);
   }
+}
 
 function JoinAudioDotComButton() {
   return (
     <a
-            onClick={() => {
-              handleButtonClick();
-            }}
-            href="https://audio.com/auth/sign-up?mtm_campaign=audacityteamorg&mtm_content=Block_button"
-            className="px-6 py-4 bg-blue-700 w-fit text-white rounded hover:bg-blue-600"
-          >
-            Join for free
-          </a>
-  )
+      onClick={() => {
+        handleButtonClick();
+      }}
+      href="https://audio.com/auth/sign-up?mtm_campaign=audacityteamorg&mtm_content=Block_button"
+      className="px-6 py-4 bg-blue-700 w-fit text-white rounded hover:bg-blue-600"
+    >
+      Join for free
+    </a>
+  );
 }
 
-export default JoinAudioDotComButton
+export default JoinAudioDotComButton;

--- a/src/components/button/JoinAudioDotComButton.jsx
+++ b/src/components/button/JoinAudioDotComButton.jsx
@@ -18,7 +18,7 @@ function JoinAudioDotComButton() {
               handleButtonClick();
             }}
             href="https://audio.com/auth/sign-up?mtm_campaign=audacityteamorg&mtm_content=Block_button"
-            className="px-4 py-2 bg-blue-700 w-fit text-white rounded hover:bg-blue-600"
+            className="px-6 py-4 bg-blue-700 w-fit text-white rounded hover:bg-blue-600"
           >
             Join for free
           </a>

--- a/src/components/button/JoinAudioDotComButton.jsx
+++ b/src/components/button/JoinAudioDotComButton.jsx
@@ -1,0 +1,28 @@
+import React from 'react'
+
+function handleButtonClick() {
+    if (typeof _paq !== "undefined") {
+      _paq.push([
+        "trackEvent",
+        "CTA Button",
+        "audio.com CTA",
+        "audio.com block CTA",
+      ]);
+    }
+  }
+
+function JoinAudioDotComButton() {
+  return (
+    <a
+            onClick={() => {
+              handleButtonClick();
+            }}
+            href="https://audio.com/auth/sign-up?mtm_campaign=audacityteamorg&mtm_content=Block_button"
+            className="px-4 py-2 bg-blue-700 w-fit text-white rounded hover:bg-blue-600"
+          >
+            Join for free
+          </a>
+  )
+}
+
+export default JoinAudioDotComButton

--- a/src/components/button/PlatformDownloadMuseHubButton.jsx
+++ b/src/components/button/PlatformDownloadMuseHubButton.jsx
@@ -1,13 +1,23 @@
 import React from "react";
 
-function AudacityInstallerButton(props) {
+function PlatformDownloadMuseHubButton(props) {
   const { museHubReleaseData } = props;
+
   function onClickButtonHandler() {
+    if (typeof _paq !== "undefined") {
+      _paq.push([
+        "trackEvent",
+        "Download Button",
+        "Download Muse Hub",
+        `Download Muse Hub button ${OS}`,
+      ]);
+    }
+
     setTimeout(() => {
-        window.location.href = "/post-download";
-      }, 2000);
+      window.location.href = "/post-download";
+    }, 2000);
   }
-  
+
   return (
     <a
       onClick={onClickButtonHandler}
@@ -19,4 +29,4 @@ function AudacityInstallerButton(props) {
   );
 }
 
-export default AudacityInstallerButton;
+export default PlatformDownloadMuseHubButton;

--- a/src/components/card/AudioDotComCard.jsx
+++ b/src/components/card/AudioDotComCard.jsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+function AudioDotComCard(props) {
+  const { title, icon, body, img } = props;
+  return (
+    <div
+      className="p-4 rounded-lg flex flex-col text-left justify-between border"
+    >
+      <span className={`icon icon-medium ${icon} text-blue-600`}></span>
+      <div>
+        <small>{title}</small>
+        <p>{body}</p>
+      </div>
+    </div>
+  );
+}
+
+export default AudioDotComCard;

--- a/src/components/card/DownloadCard.jsx
+++ b/src/components/card/DownloadCard.jsx
@@ -12,6 +12,10 @@ function DownloadCard(props) {
         `${OS + " " + title + " " + downloadType}`,
       ]);
     }
+
+    setTimeout(() => {
+      window.location.href = "/post-download";
+    }, 2000);
   }
 
   return (

--- a/src/components/card/DownloadCard.jsx
+++ b/src/components/card/DownloadCard.jsx
@@ -3,7 +3,7 @@ import React from "react";
 function DownloadCard(props) {
   const { OS, title, downloadURL, downloadType, checksum } = props;
 
-  function handleButtonClick() {
+  function handleDownloadButtonClick() {
     if (typeof _paq !== "undefined") {
       _paq.push([
         "trackEvent",
@@ -24,7 +24,7 @@ function DownloadCard(props) {
         <h2 className="text-xl font-semibold">{title}</h2>
         <a
           onClick={() => {
-            handleButtonClick();
+            handleDownloadButtonClick();
           }}
           href={downloadURL}
           className="flex justify-center text-center items-center px-4 h-12 w-full sm:w-fit bg-slate-200 hover:bg-slate-300 text-base text-black rounded"

--- a/src/components/card/FeatureCard.jsx
+++ b/src/components/card/FeatureCard.jsx
@@ -1,11 +1,10 @@
-import React from "react";
 import '../../styles/icons.css'
 
 function FeatureCard(props) {
   const { icon, title, description } = props;
 
   return (
-    <div className="h-full col-span-12 sm:col-span-6 xl:col-span-3 p-4 md:p-6 border drop-shadow-sm md:drop-shadow-lg bg-white rounded-lg flex flex-col md:gap-2">
+    <div className="h-full col-span-6 xl:col-span-3 p-4 md:p-6 border drop-shadow-sm md:drop-shadow-lg bg-white rounded-lg flex flex-col md:gap-2">
       <span className={`icon icon-medium text-blue-700 ${icon}`}></span>
       <p className="text-lg font-semibold">{title}</p>
       <p className="">{description}</p>

--- a/src/layouts/DownloadPageLayout.astro
+++ b/src/layouts/DownloadPageLayout.astro
@@ -2,6 +2,7 @@
 import BaseLayout from "./BaseLayout.astro";
 import DownloadCard from "../components/card/DownloadCard";
 import IconLinkCard from "../components/card/IconLinkCard";
+import AudacityInstallerButton from "../components/button/AudacityInstallerButton";
 import { Icon } from "astro-icon";
 import "../styles/icons.css";
 import {
@@ -68,12 +69,7 @@ const {
                 <p>via Muse Hub</p>
               </div>
 
-              <a
-                href={museHubReleaseData[0].browser_download_url}
-                class="flex justify-center text-center items-center px-4 h-12 w-full sm:w-fit bg-blue-700 hover:bg-blue-600 text-base text-white rounded"
-              >
-                Download
-              </a>
+              <AudacityInstallerButton client:load museHubReleaseData={museHubReleaseData} />
             </div>
           </div>
         </section>

--- a/src/layouts/DownloadPageLayout.astro
+++ b/src/layouts/DownloadPageLayout.astro
@@ -2,7 +2,7 @@
 import BaseLayout from "./BaseLayout.astro";
 import DownloadCard from "../components/card/DownloadCard";
 import IconLinkCard from "../components/card/IconLinkCard";
-import AudacityInstallerButton from "../components/button/AudacityInstallerButton";
+import PlatformDownloadMuseHubButton from "../components/button/PlatformDownloadMuseHubButton";
 import { Icon } from "astro-icon";
 import "../styles/icons.css";
 import {
@@ -69,7 +69,11 @@ const {
                 <p>via Muse Hub</p>
               </div>
 
-              <AudacityInstallerButton client:load museHubReleaseData={museHubReleaseData} />
+              <PlatformDownloadMuseHubButton
+                client:load
+                museHubReleaseData={museHubReleaseData}
+                OS={OS}
+              />
             </div>
           </div>
         </section>

--- a/src/pages/post-download.astro
+++ b/src/pages/post-download.astro
@@ -1,11 +1,7 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
 import JoinAudioDotComButton from "../components/button/JoinAudioDotComButton";
-import AudioDotComCard from "../components/card/AudioDotComCard";
 import "../styles/icons.css";
-import recordMemos from "../assets/img/record-memos.webp";
-import recordPodcast from "../assets/img/record-podcast.webp";
-import voiceOver from "../assets/img/voice-over.webp";
 import FeatureCard from "../components/card/FeatureCard";
 ---
 
@@ -17,13 +13,13 @@ import FeatureCard from "../components/card/FeatureCard";
   </section>
 
   <section class="mx-8 max-w-screen-md xl:max-w-screen-lg md:mx-auto">
-    <div class="py-12 flex flex-col items-center">
+    <div class="py-8 sm:py-12 flex flex-col items-center">
       <div class="text-center">
         <h1>
           Sign up to Audacity's cloud saving platform and access your
           projects from anywhere!
         </h1>
-        <div class="mt-8"><JoinAudioDotComButton /></div>
+        <div class="mt-12"><JoinAudioDotComButton /></div>
       </div>
 
       <div class="grid grid-cols-6 sm:grid-cols-12 w-full gap-4 m-16">
@@ -40,7 +36,7 @@ import FeatureCard from "../components/card/FeatureCard";
       <FeatureCard
         icon="icon-pen"
         title="Transcribe your audio"
-        description="Turn your audio into searchable text, making it easier to organize, search, and share across different platforms."
+        description="Free automatic AI transcription for your podcasts or voice overs, providing fast and accurate text for easy editing and content creation."
       />
       <FeatureCard
         icon="icon-globe"

--- a/src/pages/post-download.astro
+++ b/src/pages/post-download.astro
@@ -36,7 +36,7 @@ import FeatureCard from "../components/card/FeatureCard";
       <FeatureCard
         icon="icon-pen"
         title="Transcribe your audio"
-        description="Free automatic AI transcription for your podcasts or voice overs, providing fast and accurate text for easy editing and content creation."
+        description="Free AI-powered transcription for your podcasts or voice overs, delivering fast and precise text for effortless editing."
       />
       <FeatureCard
         icon="icon-globe"

--- a/src/pages/post-download.astro
+++ b/src/pages/post-download.astro
@@ -1,0 +1,53 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import JoinAudioDotComButton from "../components/button/JoinAudioDotComButton";
+import AudioDotComCard from "../components/card/AudioDotComCard";
+import "../styles/icons.css";
+import recordMemos from "../assets/img/record-memos.webp";
+import recordPodcast from "../assets/img/record-podcast.webp";
+import voiceOver from "../assets/img/voice-over.webp";
+import FeatureCard from "../components/card/FeatureCard";
+---
+
+<BaseLayout title="Audacity ® | post-download">
+  <section>
+    <div class="text-center bg-blue-700 py-4">
+      <p class="text-lg text-white">Thank you for downloading Audacity!</p>
+    </div>
+  </section>
+
+  <section class="mx-8 max-w-screen-md xl:max-w-screen-lg md:mx-auto">
+    <div class="py-12 flex flex-col items-center">
+      <div class="text-center">
+        <h1>
+          Sign up to Audacity's cloud saving platform and access your
+          projects from anywhere!
+        </h1>
+        <div class="mt-8"><JoinAudioDotComButton /></div>
+      </div>
+
+      <div class="grid grid-cols-6 sm:grid-cols-12 w-full gap-4 m-16">
+        <FeatureCard
+        icon="icon-cloud"
+        title="Secure cloud storage"
+        description="Keep your projects safe and accessible with cloud storage. Access your work anywhere and never lose a file."
+      />
+      <FeatureCard
+        icon="icon-note"
+        title="Share your creations"
+        description="Upload and share your audio from Audacity with just a few clicks. Quick, easy, and built for creators."
+      />
+      <FeatureCard
+        icon="icon-pen"
+        title="Transcribe your audio"
+        description="Turn your audio into searchable text, making it easier to organize, search, and share across different platforms."
+      />
+      <FeatureCard
+        icon="icon-globe"
+        title="Explore new sounds"
+        description="Collaborate with other creators, find new inspiration, and discover sounds to enhance and elevate your projects."
+      />
+      </div>
+    </div>
+  </section>
+</BaseLayout>

--- a/src/styles/icons.css
+++ b/src/styles/icons.css
@@ -27,6 +27,10 @@
     content: "\F359"
 }
 
+.icon-cloud:before {
+    content: "\F435"
+}
+
 .icon-export:before {
     content: "\EF24"
 }
@@ -89,4 +93,16 @@
 
 .icon-times:before {
     content: "\EF14"
+}
+
+.icon-pen:before {
+    content: "\EF63"
+}
+
+.icon-note:before {
+    content: "\F360"
+}
+
+.icon-globe:before {
+    content: "\F3B6"
 }

--- a/src/styles/input.css
+++ b/src/styles/input.css
@@ -4,7 +4,7 @@
 
 @layer base {
     h1 {
-        @apply text-2xl lg:text-4xl text-gray-900 font-semibold leading-tight
+        @apply text-2xl lg:text-4xl text-gray-900 font-semibold leading-tight mt-4
     }
 
     h2 {


### PR DESCRIPTION
This pull request adds a timeout to the download button which, after 2 seconds, redirects the User to a post-download page. The post-download page contains a 'thank you' banner as well as promotional content for audio.com (including a 'Join now' CTA). 

One thing worth considering is what happens if a User cancels their download as they will still be redirected. I am not yet sure how to solve this... 