### PR TITLE
Repair footer grid layout

### DIFF
--- a/src/components/footer/Footer.astro
+++ b/src/components/footer/Footer.astro
@@ -29,7 +29,7 @@ const activePreReleaseAriaLabel =
       </p>
     </div>
     <div
-      class="col-start-2 col-span-5 row-start-2 md:col-start-2 md:col-span-2 lg:col-start-6 lg:row-start-1"
+      class="col-start-2 col-span-10 row-start-2 md:col-start-2 md:col-span-3 lg:col-start-6 lg:col-span-2 lg:row-start-1"
     >
       <p class="footer-list-heading">Links</p>
       <ul class="mt-2 footer-link-list space-y-2 md:space-y-0">
@@ -47,7 +47,6 @@ const activePreReleaseAriaLabel =
             >Cloud Saving</a
           >
         </li>
-        <li>
           <li>
             <a href="/features/" aria-label="Link to Features">Features</a>
           </li>
@@ -97,11 +96,10 @@ const activePreReleaseAriaLabel =
               target="_blank">Audio.com</a
             >
           </li>
-        </li>
       </ul>
-
-      <div
-        class="col-start-7 col-span-5 row-start-2 md:col-span-2 md:col-start-4 lg:col-start-8 lg:row-start-1"
+    </div>
+    <div
+        class="col-start-2 col-span-10 row-start-3 md:col-span-3 md:col-start-5 md:row-start-2 lg:col-start-8 lg:col-span-2 lg:row-start-1"
       >
         <p class="footer-list-heading">Downloads</p>
         <ul class="mt-2 footer-link-list space-y-2 md:space-y-0">
@@ -139,7 +137,7 @@ const activePreReleaseAriaLabel =
       </div>
 
       <div
-        class="col-start-2 col-span-5 row-start-3 md:row-start-2 md:col-start-6 md:col-span-2 lg:col-start-10 lg:row-start-1"
+        class="col-start-2 col-span-10 row-start-4 md:row-start-2 md:col-start-8 md:col-span-3 lg:col-start-10 lg:col-span-2 lg:row-start-1"
       >
         <p class="footer-list-heading">Social</p>
         <ul class="mt-2 footer-link-list space-y-2 md:space-y-0">
@@ -198,7 +196,6 @@ const activePreReleaseAriaLabel =
             >.
           </p>
         </div>
-      </div>
     </div>
   </div>
 


### PR DESCRIPTION
The Downloads and Social sections were accidentally nested inside the Links list item, causing them to stack in a single column instead of appearing in their own grid columns. Also improved responsive spacing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted Tailwind grid positioning and layout for footer sections including Links, Downloads, and Social columns.

* **Bug Fixes**
  * Corrected footer list item markup structure by removing extra wrapper tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->