### PR TITLE
Prevent banner button text wrapping and add horizontal padding

### DIFF
--- a/src/components/banner/PromoBanner.tsx
+++ b/src/components/banner/PromoBanner.tsx
@@ -14,10 +14,10 @@ const DEFAULT_PROMO_STYLES: NonNullable<PromoData["styles"]> = {
 };
 
 const BASE_CONTAINER_CLASSNAME =
-  "flex flex-col lg:flex-row justify-center items-center align-start py-4 gap-3 lg:gap-6 transition-colors duration-200";
+  "flex flex-col lg:flex-row justify-center items-center align-start px-4 py-4 gap-3 lg:gap-6 transition-colors duration-200";
 const BASE_MESSAGE_CLASSNAME = "text-lg font-semibold";
 const BASE_BUTTON_CLASSNAME =
-  "flex h-8 justify-center items-center px-4 rounded-md font-semibold";
+  "flex h-8 justify-center items-center px-4 rounded-md font-semibold whitespace-nowrap";
 
 const PLACEHOLDER_CONTAINER_CLASSNAME =
   "flex flex-col lg:flex-row justify-center items-center align-start py-4 gap-3 lg:gap-6 transition-colors duration-200 opacity-0 pointer-events-none";


### PR DESCRIPTION
Add whitespace-nowrap to the CTA button so text like "Get it on MuseHub" doesn't wrap at narrow viewports. Add px-4 to the banner container so content doesn't touch the edges of the page.