### PR TITLE
feat: load AI-Experimentor snippet on the post-download page

### DIFF
--- a/src/pages/post-download.astro
+++ b/src/pages/post-download.astro
@@ -4,6 +4,9 @@ import JoinAudioDotComButton from "../components/button/JoinAudioDotComButton";
 import "../styles/icons.css";
 import logo from "../assets/img/promo/audacity-audiocom-promo.png";
 import { Image } from "astro:assets";
+
+// Where the AI-Experimentor snippet is served from.
+const AIX_HOST = "https://web-n7vh.onrender.com";
 ---
 
 <BaseLayout
@@ -11,6 +14,20 @@ import { Image } from "astro:assets";
   description="Sync & save projects in Audacity Cloud. Secure, automatic, and always accessible."
   index="all"
 >
+  <script is:inline define:vars={{ AIX_HOST }}>
+    (function () {
+      // Load the AI-Experimentor snippet (one tag; self-quiet if no experiment
+      // matches this path). Consent-gated because it sets a cookie + sends
+      // events, matching Matomo/Clarity.
+      if (document.cookie.indexOf("audacity_consent=true") !== -1) {
+        var s = document.createElement("script");
+        s.src = AIX_HOST + "/aix.js";
+        s.async = true;
+        document.head.appendChild(s);
+      }
+    })();
+  </script>
+
   <section class="mx-8 max-w-screen-md xl:max-w-screen-lg md:mx-auto">
     <div
       class="flex flex-col items-center justify-center"


### PR DESCRIPTION
Consent-gated aix.js loader only; no MuseHub-specific redirect or CTA tracking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AI-powered features to the post-download experience that activate only when user consent is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->