### PR TITLE
feat: allow forcing dark experiments via ?ab= URL override

### DIFF
--- a/src/hooks/useExperiment.ts
+++ b/src/hooks/useExperiment.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { getExperiment } from "../assets/data/experiments";
-import { getAbId, getVariant } from "../utils/experiment";
+import { resolveVariant } from "../utils/experiment";
 
 type UseExperimentResult = {
   variant: string | null;
@@ -15,18 +15,12 @@ export function useExperiment(experimentName: string): UseExperimentResult {
 
   useEffect(() => {
     const experiment = getExperiment(experimentName);
-    if (!experiment || !experiment.enabled) {
-      setResult({ variant: null, isReady: true });
-      return;
-    }
-
-    const abId = getAbId();
-    if (abId === null) {
-      setResult({ variant: null, isReady: true });
-      return;
-    }
-
-    setResult({ variant: getVariant(experiment, abId), isReady: true });
+    // resolveVariant handles the ?ab= force (any experiment) and the
+    // enabled-only auto-assignment, so the hook just reflects its result.
+    setResult({
+      variant: experiment ? resolveVariant(experiment) : null,
+      isReady: true,
+    });
   }, [experimentName]);
 
   return result;

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -45,9 +45,10 @@ const hasEligibleExitPopup =
     path: currentPath,
   }).length > 0;
 const shouldEnableExitIntentPopup = hasEligibleExitPopup;
-const experimentBootstrapData = experiments.filter(
-  (experiment) => experiment.enabled,
-);
+// Serialize every experiment (not just enabled ones) so a ?ab=name:variant URL
+// can force-preview a dark experiment. Disabled experiments are never
+// auto-assigned to real visitors — see the bootstrap loop below.
+const experimentBootstrapData = experiments;
 ---
 
 <!doctype html>
@@ -158,13 +159,14 @@ const experimentBootstrapData = experiments.filter(
         var abId = parseInt(getCookieValue("aud_ab_id"), 10);
         for (var i = 0; i < experiments.length; i++) {
           var experiment = experiments[i];
-          if (!experiment.enabled) continue;
 
           var variant = getForcedVariant(experiment.name);
           if (variant && !isValidVariant(experiment, variant)) {
             variant = null;
           }
-          if (!variant && Number.isFinite(abId)) {
+          // A valid ?ab= force previews any experiment, enabled or not.
+          // Otherwise only enabled experiments auto-assign a cohort.
+          if (!variant && experiment.enabled && Number.isFinite(abId)) {
             var slot = hashToSlot(abId, experiment.name);
             var cumulative = 0;
             for (var j = 0; j < experiment.variants.length; j++) {

--- a/src/utils/experiment.test.ts
+++ b/src/utils/experiment.test.ts
@@ -1,6 +1,15 @@
-import { describe, expect, test } from "bun:test";
-import { hashToSlot, getVariant } from "./experiment";
+import { afterEach, describe, expect, test } from "bun:test";
+import { hashToSlot, getVariant, resolveVariant } from "./experiment";
 import type { Experiment } from "../assets/data/experiments";
+
+// resolveVariant / getVariant read window.location.search (?ab= force) and
+// document.cookie (aud_ab_id). Stub them so the force/cohort logic runs in node.
+type StubGlobals = { window: unknown; document: unknown };
+const stub = globalThis as unknown as StubGlobals;
+function setEnv(ab: string | null, abId: number | null): void {
+  stub.window = { location: { search: ab ? `?ab=${ab}` : "" } };
+  stub.document = { cookie: abId === null ? "" : `aud_ab_id=${abId}` };
+}
 
 describe("hashToSlot", () => {
   test("returns a number between 0 and 99", () => {
@@ -83,5 +92,98 @@ describe("getVariant", () => {
     const v1 = getVariant(fiftyFifty, 42);
     const v2 = getVariant(fiftyFifty, 42);
     expect(v1).toBe(v2);
+  });
+});
+
+describe("getVariant ?ab= override", () => {
+  const exp: Experiment = {
+    name: "demo",
+    variants: [
+      { name: "control", weight: 50 },
+      { name: "treatment", weight: 50 },
+    ],
+    enabled: true,
+  };
+  const origWindow = stub.window;
+  afterEach(() => {
+    stub.window = origWindow;
+  });
+
+  test("a valid forced variant wins over the hash", () => {
+    setEnv("demo:treatment", null);
+    for (let id = 0; id < 50; id++)
+      expect(getVariant(exp, id)).toBe("treatment");
+  });
+
+  test("an invalid forced variant is ignored, not returned as-is", () => {
+    setEnv("demo:bogus", null);
+    const v = getVariant(exp, 42);
+    expect(v).not.toBe("bogus");
+    expect(exp.variants.map((x) => x.name)).toContain(v);
+  });
+
+  test("a force for a different experiment is not applied", () => {
+    setEnv("other:treatment", null);
+    const v = getVariant(exp, 42);
+    expect(exp.variants.map((x) => x.name)).toContain(v);
+  });
+});
+
+describe("resolveVariant", () => {
+  const live: Experiment = {
+    name: "live",
+    variants: [
+      { name: "control", weight: 50 },
+      { name: "treatment", weight: 50 },
+    ],
+    enabled: true,
+  };
+  const dark: Experiment = { ...live, name: "dark", enabled: false };
+
+  const origWindow = stub.window;
+  const origDocument = stub.document;
+  afterEach(() => {
+    stub.window = origWindow;
+    stub.document = origDocument;
+  });
+
+  test("forces a DARK experiment via ?ab=, even with no cookie", () => {
+    setEnv("dark:treatment", null);
+    expect(resolveVariant(dark)).toBe("treatment");
+  });
+
+  test("a dark experiment stays unassigned without a force (no leakage)", () => {
+    setEnv(null, 12345);
+    expect(resolveVariant(dark)).toBeNull();
+  });
+
+  test("a force wins over the cohort assignment", () => {
+    setEnv("live:treatment", 12345);
+    expect(resolveVariant(live)).toBe("treatment");
+  });
+
+  test("an enabled experiment auto-assigns a valid arm with a cookie", () => {
+    setEnv(null, 12345);
+    const v = resolveVariant(live);
+    expect(v).not.toBeNull();
+    expect(live.variants.map((x) => x.name)).toContain(v as string);
+  });
+
+  test("an enabled experiment is null without a cookie or force", () => {
+    setEnv(null, null);
+    expect(resolveVariant(live)).toBeNull();
+  });
+
+  test("an invalid forced arm does not apply to a dark experiment", () => {
+    setEnv("dark:bogus", null);
+    expect(resolveVariant(dark)).toBeNull();
+  });
+
+  test("an invalid forced arm on an enabled experiment falls back to cohort", () => {
+    setEnv("live:bogus", 12345);
+    const v = resolveVariant(live);
+    expect(v).not.toBe("bogus");
+    expect(v).not.toBeNull();
+    expect(live.variants.map((x) => x.name)).toContain(v as string);
   });
 });

--- a/src/utils/experiment.ts
+++ b/src/utils/experiment.ts
@@ -36,7 +36,9 @@ export function getForcedVariant(experimentName: string): string | null {
 
 export function getVariant(experiment: Experiment, abId: number): string {
   const forced = getForcedVariant(experiment.name);
-  if (forced !== null) return forced;
+  if (forced !== null && experiment.variants.some((v) => v.name === forced)) {
+    return forced;
+  }
   const slot = hashToSlot(abId, experiment.name);
   let cumulative = 0;
   for (const v of experiment.variants) {
@@ -46,13 +48,33 @@ export function getVariant(experiment: Experiment, abId: number): string {
   return experiment.variants[experiment.variants.length - 1].name;
 }
 
-export function getAllAssignments(): Record<string, string> {
+/**
+ * Resolve the active variant for an experiment:
+ *  - a valid forced variant (?ab=name:variant) always wins — this previews any
+ *    experiment, enabled or not, with or without a cohort cookie;
+ *  - otherwise only enabled experiments auto-assign a cohort by hashing the
+ *    aud_ab_id cookie;
+ *  - returns null when nothing applies.
+ *
+ * Keep this in sync with the inline bootstrap in BaseLayout.astro, which has to
+ * re-implement the same rule in vanilla JS to set data-exp-* before paint.
+ */
+export function resolveVariant(experiment: Experiment): string | null {
+  const forced = getForcedVariant(experiment.name);
+  if (forced !== null && experiment.variants.some((v) => v.name === forced)) {
+    return forced;
+  }
+  if (!experiment.enabled) return null;
   const abId = getAbId();
-  if (abId === null) return {};
+  if (abId === null) return null;
+  return getVariant(experiment, abId);
+}
+
+export function getAllAssignments(): Record<string, string> {
   const result: Record<string, string> = {};
   for (const exp of experiments) {
-    if (!exp.enabled) continue;
-    result[exp.name] = getVariant(exp, abId);
+    const variant = resolveVariant(exp);
+    if (variant !== null) result[exp.name] = variant;
   }
   return result;
 }


### PR DESCRIPTION
## Summary

A small, general improvement to the experiment harness: **a valid `?ab=name:variant` URL override now force-previews any experiment — even a disabled (unlaunched) one — without exposing it to real traffic.**

Previously `?ab=` only worked for `enabled` experiments, because disabled ones were filtered out of the bootstrap and skipped in the hook. So QA-ing an unlaunched experiment meant temporarily flipping its `enabled` flag (which exposes it to the live cohort).

## Change

Centralizes variant resolution in a new `resolveVariant()`:
> A valid forced variant always wins (any experiment, with or without a cohort cookie). Otherwise, only **enabled** experiments auto-assign a cohort to real visitors.

Wired into the three readers:
- `experiment.ts` — add `resolveVariant()`; validate the forced variant in `getVariant()`; route `getAllAssignments()` through it.
- `useExperiment.ts` — hook reflects `resolveVariant()` (hook-driven arms).
- `BaseLayout.astro` — inline bootstrap serializes all experiments and gates auto-assignment on `enabled` (CSS-driven arms).

Side benefit: an invalid forced arm name (e.g. `?ab=foo:bogus`) is now ignored consistently across all paths and falls back to normal assignment.

```
/?ab=nav-logo:text-only
/?ab=nav-logo:text-only|musehub-download:direct-download
```

## Verification
- `astro check` 0 errors; production build clean.
- Verified against **disabled** experiments (both the CSS bootstrap path and the `useExperiment` hook path): forcing applies the arm, no `?ab=` leaves the experiment unassigned (no leakage), invalid arm ignored.
- Full e2e suite green.

## Note
Serializing all experiments means disabled experiment names/variants appear in page source. Not sensitive, but worth knowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * A/B experiment forced variants now apply correctly even when the experiment is disabled

* **Refactoring**
  * Improved internal variant resolution and experiment assignment logic

* **Tests**
  * Enhanced test coverage for variant forcing and cohort assignment behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->